### PR TITLE
Support multiple protocols

### DIFF
--- a/node/src/connection.rs
+++ b/node/src/connection.rs
@@ -58,12 +58,11 @@ impl Connection {
                     Err(_) => {
                         return Err("peer closed connection".into());
                     }
-                    Ok(message) => match self.message_received(&message.freeze()).await {
-                        Err(_) => {
+                    Ok(message) => {
+                        if self.message_received(&message.freeze()).await.is_err() {
                             return Err("peer closed connection".into());
                         }
-                        Ok(_) => {}
-                    },
+                    }
                 },
             }
         }

--- a/node/src/connection.rs
+++ b/node/src/connection.rs
@@ -72,7 +72,7 @@ impl Connection {
     async fn message_received(&mut self, message: &Bytes) -> Result<(), Box<dyn Error>> {
         use futures::SinkExt;
 
-        let message = protocol::deserialize_message(message).unwrap();
+        let message = protocol::Message::from_bytes(message).unwrap();
         if let Some(response) = message.response_for_received() {
             match self.writer.send(response).await {
                 Err(_) => {

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -23,12 +23,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let framed_writer = FramedWrite::new(w, LengthDelimitedCodec::new());
         let mut conn = connection::Connection::new(framed_reader, framed_writer);
         tokio::spawn(async move {
-            match conn.start_from_connect().await {
-                Err(_) => {
-                    println!("peer closed connection");
-                }
-                Ok(_) => {}
-            }
+            conn.start_from_connect().await.unwrap();
         });
     }
 
@@ -45,12 +40,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 let mut conn = connection::Connection::new(framed_reader, framed_writer);
 
                 tokio::spawn(async move {
-                    match conn.start_from_accept().await {
-                        Err(e) => {
-                            println!("Connection shutdown: {:?}", e);
-                            return;
-                        }
-                        Ok(_) => {}
+                    if conn.start_from_accept().await.is_err() {
+                        println!("Peer closed connection")
                     }
                 });
             }

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -29,8 +29,8 @@ impl Message {
 
     pub fn response_for_received(&self) -> Option<Message> {
         match self {
-            Message::Ping(m) => return m.response_for_received(),
-        };
+            Message::Ping(m) => m.response_for_received(),
+        }
     }
 }
 

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -1,3 +1,5 @@
+use bytes::Bytes;
+use std::error::Error;
 extern crate flexbuffers;
 extern crate serde;
 // #[macro_use]
@@ -5,45 +7,84 @@ extern crate serde;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct PingMessage {
+    pub message: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub enum Message {
-    Ping { message: String },
+    Ping(PingMessage),
 }
 
 pub trait Protocol {
-    fn start(&mut self) -> Option<Message>;
-    fn received(&mut self, message: &Message) -> Option<Message>;
+    fn start(&self) -> Option<Message>;
+    fn response_for_received(&self) -> Option<Bytes>;
+}
+
+impl Message {
+    pub fn as_bytes(&self) -> Option<Bytes> {
+        let mut s = flexbuffers::FlexbufferSerializer::new();
+        self.serialize(&mut s).unwrap();
+        Some(Bytes::from(s.take_buffer()))
+    }
+}
+
+pub fn deserialize_message(b: &[u8]) -> Result<Message, Box<dyn Error>> {
+    Ok(flexbuffers::from_slice(b)?)
 }
 
 impl Protocol for Message {
-    fn start(&mut self) -> Option<Message> {
-        Some(Message::Ping {
+    fn start(&self) -> Option<Message> {
+        Some(Message::Ping(PingMessage {
             message: String::from("ping"),
-        })
+        }))
     }
 
-    fn received(&mut self, _message: &Message) -> Option<Message> {
-        Some(Message::Ping {
-            message: String::from("pong"),
-        })
+    fn response_for_received(&self) -> Option<Bytes> {
+        match self {
+            Message::Ping(received) => {
+                println!("Received {:?}", received.message);
+                if received.message == "ping" {
+                    let response = Message::Ping(PingMessage {
+                        message: String::from("pong"),
+                    });
+                    let mut s = flexbuffers::FlexbufferSerializer::new();
+                    response.serialize(&mut s).unwrap();
+                    Some(Bytes::from(s.take_buffer()))
+                } else {
+                    None
+                }
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::Message;
+    use super::PingMessage;
     use crate::protocol::serde::Serialize;
     use bytes::Bytes;
 
     #[test]
     fn it_serialized_ping_message() {
-        let ping_message = Message::Ping {
+        let ping_message = Message::Ping(PingMessage {
             message: String::from("ping"),
-        };
+        });
         let mut s = flexbuffers::FlexbufferSerializer::new();
         ping_message.serialize(&mut s).unwrap();
         let b = Bytes::from(s.take_buffer());
 
         let m: Message = flexbuffers::from_slice(&b).unwrap();
-        assert_eq!(m, ping_message)
+        assert_eq!(m, ping_message);
+
+        use super::Protocol;
+        let x = m.start().unwrap();
+        assert_eq!(
+            x,
+            Message::Ping(PingMessage {
+                message: String::from("ping")
+            })
+        );
     }
 }

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -27,10 +27,10 @@ impl Message {
         self.serialize(&mut s).unwrap();
         Some(Bytes::from(s.take_buffer()))
     }
-}
 
-pub fn deserialize_message(b: &[u8]) -> Result<Message, Box<dyn Error>> {
-    Ok(flexbuffers::from_slice(b)?)
+    pub fn from_bytes(b: &[u8]) -> Result<Self, Box<dyn Error>> {
+        Ok(flexbuffers::from_slice(b)?)
+    }
 }
 
 impl Protocol for Message {


### PR DESCRIPTION
Abstract out protocols to enable easier development and testing of the various protocols we'll need to add on top of the p2p connections.