### PR TITLE
fix notifier

### DIFF
--- a/node/connection/src/lib.rs
+++ b/node/connection/src/lib.rs
@@ -123,7 +123,6 @@ pub async fn start_listen(
             loop {
                 // Asynchronously wait for an inbound TcpStream.
                 log::info!("Starting accept");
-                notifier.notify_one();
                 match listener.accept().await {
                     Ok((stream, peer_address)) => {
                         log::info!("Accepted connection from {:?}", peer_address);
@@ -210,6 +209,7 @@ where
                 if handle_received(writer, msg).await.is_err() {
                     return Err("Message handling failure: Closing peer connection".into());
                 } else {
+                    log::debug!("Message handled");
                     notifier.notify_one();
                 }
             },
@@ -356,29 +356,26 @@ mod tests {
 
         let (send_to_all_tx, send_to_all_rx) = broadcast::channel::<Bytes>(32);
 
-        let notify = Arc::new(Notify::new());
-        let notify_listen_cloned = notify.clone();
-        let notify_connect_cloned = notify.clone();
-
         tokio::spawn(async move {
             start_listen(
-                "localhost:6680".to_string(),
+                "127.0.0.1:6680".to_string(),
                 listen_manager_cloned,
                 32,
                 send_to_all_tx,
-                notify_listen_cloned,
+                Arc::new(Notify::new()),
             )
             .await;
         });
 
-        notify.notified().await;
+        let notify = Arc::new(Notify::new());
+        let notify_clone = notify.clone();
 
         let _ = connect(
-            "localhost:6680".to_string(),
+            "127.0.0.1:6680".to_string(),
             connect_manager_cloned,
             32,
             send_to_all_rx,
-            notify_connect_cloned,
+            notify_clone,
         )
         .await;
 

--- a/node/connection/src/lib.rs
+++ b/node/connection/src/lib.rs
@@ -210,7 +210,7 @@ where
                 if handle_received(writer, msg).await.is_err() {
                     return Err("Message handling failure: Closing peer connection".into());
                 } else {
-                    notifier.notified();
+                    notifier.notify_one();
                 }
             },
             Ok(msg_bytes) = send_to_all_receiver.recv() => {


### PR DESCRIPTION
i wanted to understand how this notifier worked just in case the extra one i added for the tests would cause problems with the heartbeat function, and it looks like the wrong notifier is set in `start_message_handler`, its not actually doing anything. 

I updated it to use `notifier.notify_one();`

Is this purpose of this to stop the heartbeat if a message has already been handled to reduce the amount of messages being sent? 