### PR TITLE
Feat/add uhpo crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ simulations/logs/*
 simulations/*.toolbox
 venv
 target
-todos
+todo

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ simulations/logs/*
 simulations/*.toolbox
 venv
 target
+todos

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.enableFiletypes": [
+        "!rust"
+    ]
+}

--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -134,6 +134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +175,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bech32"
@@ -261,6 +273,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +295,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
@@ -413,6 +437,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,10 +520,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "env_logger"
@@ -505,6 +565,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,11 +592,41 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15d14128f06405808ce75bfebe11e9b0f9da18719ede6d7bdb1702d6bfe0f7e8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "num_enum",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]
@@ -657,6 +763,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,10 +825,253 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+ "smallvec",
+ "utf8_iter",
+]
 
 [[package]]
 name = "indexmap"
@@ -725,6 +1093,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,12 +1116,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "jsonrpc"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3662a38d341d77efecb73caf01420cfa5aa63c0253fd7bc05289ef9f6616e1bf"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "minreq",
  "serde",
  "serde_json",
@@ -764,6 +1147,18 @@ name = "libc"
 version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "log"
@@ -785,6 +1180,12 @@ name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -842,6 +1243,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.60",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -907,10 +1325,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1106,6 +1594,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
+name = "reqwest"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "run"
 version = "0.1.0"
 dependencies = [
@@ -1142,10 +1689,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.5.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "secp256k1"
@@ -1166,6 +1775,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1433bd67156263443f14d603720b082dd3121779323fce20cba2aa07b874bc1b"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+dependencies = [
+ "bitflags 2.5.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1215,10 +1847,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.8"
+name = "serde_urlencoded"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1242,6 +1886,12 @@ checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snow"
@@ -1268,6 +1918,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sqlite"
@@ -1298,6 +1954,12 @@ dependencies = [
  "libc",
  "sqlite3-src",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
@@ -1334,6 +1996,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,6 +2068,16 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1385,6 +2107,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.60",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
 ]
 
 [[package]]
@@ -1462,6 +2205,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
 name = "tracing"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,6 +2292,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,6 +2311,9 @@ dependencies = [
  "bitcoincore-rpc",
  "hex",
  "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1554,6 +2333,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,16 +2374,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "web-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -1766,6 +2665,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,7 +2731,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+
+[[package]]
+name = "zerovec"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]

--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -128,6 +128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +152,70 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
+]
+
+[[package]]
+name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals",
+ "bitcoin_hashes",
+]
+
+[[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+
+[[package]]
+name = "bitcoin"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea507acc1cd80fc084ace38544bbcf7ced7c2aa65b653b102de0ce718df668f6"
+dependencies = [
+ "base58ck",
+ "bech32",
+ "bitcoin-internals",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes",
+ "hex-conservative",
+ "hex_lit",
+ "secp256k1",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "340e09e8399c7bd8912f495af6aa58bea0c9214773417ffaa8f6460f93aaee56"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb54da0b28892f3c52203a7191534033e051b6f4b52bc15480681b57b7e036f5"
+dependencies = [
+ "bitcoin-internals",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
 ]
 
 [[package]]
@@ -573,6 +643,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex_lit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +1044,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
+dependencies = [
+ "bitcoin_hashes",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1433bd67156263443f14d603720b082dd3121779323fce20cba2aa07b874bc1b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,6 +1409,13 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "uhpo"
+version = "0.1.0"
+dependencies = [
+ "bitcoin",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -165,6 +165,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "bech32"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +191,7 @@ dependencies = [
  "hex-conservative",
  "hex_lit",
  "secp256k1",
+ "serde",
 ]
 
 [[package]]
@@ -192,6 +199,9 @@ name = "bitcoin-internals"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitcoin-io"
@@ -206,6 +216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb54da0b28892f3c52203a7191534033e051b6f4b52bc15480681b57b7e036f5"
 dependencies = [
  "bitcoin-internals",
+ "serde",
 ]
 
 [[package]]
@@ -216,6 +227,31 @@ checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
+ "serde",
+]
+
+[[package]]
+name = "bitcoincore-rpc"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aedd23ae0fd321affb4bbbc36126c6f49a32818dc6b979395d24da8c9d4e80ee"
+dependencies = [
+ "bitcoincore-rpc-json",
+ "jsonrpc",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "bitcoincore-rpc-json"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
+dependencies = [
+ "bitcoin",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -643,6 +679,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hex-conservative"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +736,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "jsonrpc"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3662a38d341d77efecb73caf01420cfa5aa63c0253fd7bc05289ef9f6616e1bf"
+dependencies = [
+ "base64",
+ "minreq",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +793,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "minreq"
+version = "2.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fdef521c74c2884a4f3570bcdb6d2a77b3c533feb6b27ac2ae72673cc221c64"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -889,6 +960,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "predicates"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +1029,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
 ]
 
 [[package]]
@@ -1044,13 +1142,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "secp256k1"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
  "bitcoin_hashes",
+ "rand",
  "secp256k1-sys",
+ "serde",
 ]
 
 [[package]]
@@ -1086,6 +1192,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.60",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1415,6 +1532,9 @@ name = "uhpo"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
+ "bitcoincore-rpc",
+ "hex",
+ "rand",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -5,5 +5,6 @@ members = [
     "config",
     "connection",    
     "run",
-    "protocol"
+    "protocol",
+    "uhpo"
 ]

--- a/node/uhpo/Cargo.toml
+++ b/node/uhpo/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoin = "0.32.2"
+bitcoin = {version = "0.32.2" , features = ["rand"] }
+rand = "0.8.5"

--- a/node/uhpo/Cargo.toml
+++ b/node/uhpo/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2021"
 [dependencies]
 bitcoin = {version = "0.32.2" , features = ["rand"] }
 rand = "0.8.5"
+bitcoincore-rpc = "0.19.0"
+hex = "0.4.3"

--- a/node/uhpo/Cargo.toml
+++ b/node/uhpo/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "uhpo"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bitcoin = "0.32.2"

--- a/node/uhpo/Cargo.toml
+++ b/node/uhpo/Cargo.toml
@@ -10,3 +10,8 @@ bitcoin = {version = "0.32.2" , features = ["rand"] }
 rand = "0.8.5"
 bitcoincore-rpc = "0.19.0"
 hex = "0.4.3"
+
+[dev-dependencies]
+reqwest = { version = "0.12.5", features = ["blocking"] }
+serde_json = "1.0.93"
+serde = { version = "1.0.152", features = ["derive"] }

--- a/node/uhpo/Readme.md
+++ b/node/uhpo/Readme.md
@@ -1,0 +1,59 @@
+## UHPO (Unspent Hasher PayOut) Crate
+
+This Rust crate provides functionality to build UHPO transactions, which are used for secure payouts in Braidpool.
+
+### Features
+
+- Build and sign Payout Update Transactions
+- Build and sign Payout Settlement Transactions
+- Example implementation demonstrating the usage of the crate
+
+
+### Prerequisites
+
+- Rust and Cargo
+- Docker [for nigiri]
+
+
+### Installation and Setup
+
+1. In Order to test and implement this crate locally one might need to use Regtest environment. Testcases uses nigiri to manage services like `regtest` , `electrs` and `esplora`. U can install nigiri with
+
+```bash
+$ curl https://getnigiri.vulpem.com | bash
+``` 
+
+2. Start Regtest and other services with.
+```bash
+$ nigiri start
+```
+
+3. One can stop, reset nigiri and restart it with
+```bash
+$ nigiri stop --delete && nigiri start
+```
+
+### Testing
+To run the tests for this crate, use the following command:
+```bash
+$ cargo test --package uhpo --test standard_flow -- standard_flow --exact --show-output
+```
+
+<hr>
+
+### Crate Structure
+```text
+    .
+    ├── Cargo.toml
+    ├── Readme.md
+    ├── docs
+    │   └── spec.md
+    ├── src
+    │   ├── error.rs
+    │   ├── lib.rs
+    │   ├── payout_settlement.rs
+    │   └── payout_update.rs
+    └── tests
+        ├── standard_flow.rs
+        └── utils.rs
+```

--- a/node/uhpo/docs/spec.md
+++ b/node/uhpo/docs/spec.md
@@ -1,0 +1,320 @@
+# Braidpool UHPO Spec
+
+## Objective
+
+---
+
+- rust crate to build uhpo transactions.
+- Include unit and integration tests for the crate.
+
+Reference Image 
+
+![https://gist.githubusercontent.com/pool2win/77bb9b98f9f3b8c0f90963343c3c840f/raw/8fa2481728e7c12d553608af23ca6e551c7c90c1//uhpo-success.png](https://gist.githubusercontent.com/pool2win/77bb9b98f9f3b8c0f90963343c3c840f/raw/8fa2481728e7c12d553608af23ca6e551c7c90c1//uhpo-success.png)
+
+## Functional Requirements
+
+- Should be able to build `payout-update` and `payout-settlement` Transaction.
+
+## **Specification**
+
+---
+
+### Building Payout-Update/Payout-Settlement Transaction
+
+`payout-update`  is transaction which merges coinbase funds after they achieve maturity. and accumulates in a `eltoo` fashion. payout-update transaction will be cached and broadcasted onchain when coinbase attains maturity..
+
+```rust
+pub struct PayoutUpdate {
+    transaction: Transaction,
+    fee: u64 
+}
+// Q. let's try to put in the fields here, so we develop an understanding of what is required here.
+// A. I could come up with only two params for now. I will add further params as we build.
+
+[KP] The fee can be derived from the transaction, so we don't need the fee field.
+
+// Q. We should use the builder pattern here. You'll find writeups on Rust builder pattern. I think rust-bitcoin uses it too?
+// I tried modifying to match it to follow builder pattern.
+// new() - builds base templete for payout-update transaction
+// add-sig() : signs and adds signature to txs
+// builds : returns entire transaction.
+
+[KP] - s/add-sig/add_sig and s/builds/build
+
+[KP] - generally it is not good to shorten names. next_out_address. Do you want to say next_output_address?
+
+[KP] - I haven't reviewed the body of the functions below yet. We just want to focus on the signatures of the functions atm.
+
+[KP] -  Re add_coinbase_sig: Rust doesn't do function overloading. So we'll need two functions with different names.
+
+impl PayoutUpdate {
+
+    pub fn new(
+        prev_update_tx: Option<PayoutUpdateTransaction>, // optional because initial payout-update tx is null.
+        coinbase: Transaction,
+        next_out_address: Address,
+    ) -> Self {
+		    /*
+				    Tx | Inputs       | Output |
+				    *****************************
+				       | coinbase     | new_payout
+				       | prev_update? |
+		    */
+        let mut tx = Transaction::new();
+
+        let fee = avg_fee.now(24);
+        let total_output_value: u64 = coinbase.outputs[0].value - fee;
+
+        if let Some(prev_tx) = prev_update_tx {
+            total_output_value += prev_tx.outputs[0].value;
+        }
+
+        let output = TxOut::new(total_output_value, next_out_address.script_pubkey());
+        tx.output.extend(output);
+	
+				 let coinbase_input = TxIn {
+			            OutPoint: (coinbase.txid , 0),
+            };
+        tx.input.extend(coinbase_input);
+
+   
+        if let Some(prev_tx) = prev_update_tx {
+            let prev_input = TxIn {
+			            OutPoint: (prev_tx.txid , 0),
+            }
+            tx.input.extend(prev_input);
+        }
+
+      
+        PayoutUpdate {
+            transaction: tx,
+            fee: fee
+        }
+    }
+    
+    //  add_coinbase_sig
+    pub fn add_coinbase_sig(&mut self, private_key: &SecretKey) -> Result<(), Error> {
+		    
+		    // get taproot script pubkey for coinbase
+		    let taproot_script_pub_key = coinbase.output[0].script;
+		    				
+				let funding_output = TxOut {
+            value: self.transaction.output[0].value,
+            script_pubkey: taproot_script_pub_key,
+        };
+        
+        // compute sigHash
+        let prevout = vec![&funding_output];
+        let mut sighash_cache = SighashCache::new(&self.transaction);
+        let sighash = sighash_cache
+            .taproot_key_spend_signature_hash(0, &Prevouts::All(&prevout), sighash::TapSighashType::All)
+            .unwrap();
+           
+        let message = Message::from_digest(sighash.as_raw_hash().to_byte_array());
+        let tweaked_keypair = private_key.keypair(&secp).add_xonly_tweak(&secp, &taproot_script_pub_key.tap_tweak().to_scalar()).unwrap();
+				
+				// Sign messege Digest and add signature to witness
+        let signature = secp.sign_schnorr(&message, &tweaked_keypair);
+        secp.verify_schnorr(
+            &signature,
+            &message,
+            &taproot_script_pub_key.output_key().to_inner(),
+        ).unwrap();
+
+        let mut vec_sig = signature.serialize().to_vec();
+        vec_sig.push(0x01);
+				
+        keypath_tx.input[0].witness.push(vec_sig);
+        
+        Ok(())
+    }
+
+    pub fn add_coinbase_sig(&mut self, private_key: &SecretKey) -> Result<(), Error> {
+				// follows same pseudo code as earlier function but signs second input!
+		}
+		
+		pub fn build(self) Transaction {
+						self.transaction
+		}
+}
+```
+
+### Implementation Code for Payout Update Struct
+
+
+---
+
+```rust
+
+let coinbase_tx = Transaction::new();
+
+let coinbase_output = TxOut {
+    value: 50 * 100_000_000, // 50 BTC
+    script_pubkey: POOL_KEY,
+};
+coinbase_tx.output.push(coinbase_output);
+
+block.txdata.push(coinbase_tx);
+block.mine();
+
+// Create a random previous output transaction (prev_update_tx)
+let prev_update_tx = Transaction {
+    version: 2,
+    lock_time: 0,
+    input: vec![TxIn {
+        previous_output: OutPoint::from("prev_update_out"),
+        sequence: 0xFFFFFFFF,
+        witness: vec![],
+    }],
+    output: vec![TxOut {
+        value: 100 * 100_000_000, // 100 BTC
+        script_pubkey: TAPROOT_KEY,
+    }],
+};
+
+let payout_update = PayoutUpdate::new(
+    Some(prevout_tx),
+    coinbase_tx,
+    Address::from_string("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq").unwrap(),
+);
+
+// Generate random private keys
+let secp = Secp256k1::new();
+let privkey1 = SecretKey::new(&mut rng);
+let privkey2 = SecretKey::new(&mut rng);
+
+// Add signatures with random private keys
+payout_update.add_coinbase_sig(&privkey1).unwrap();
+payout_update.add_prevout_sig(&privkey2).unwrap();
+
+// Build the transaction
+let final_tx = payout_update.build();
+
+```
+
+## Payout Settlement
+
+---
+
+`payout-settlement`  is a transaction which spends funds from from latest `poolkey` which was used as output in `payout-update` transaction.
+
+```rust
+pub struct PayoutSettlement {
+       transaction: Transaction,
+		   fee: u64 
+}
+
+impl PayoutSettlement {
+    pub fn new(
+        latest_eltoo_out_address: Address,
+        payout_map: HashMap<Address, Amount>,
+    ) -> Self {
+        let mut tx = Transaction::new();
+
+        let fee = avg_fee.now(24);
+        
+        tx.input.extend(TxIn {
+		        outpoint : latest_eltoo_out_address,
+		        vout: 0
+        })
+        
+        payout_map.iter().for_each(|address, amount| {
+			        tx.output.extend({
+						        TxOut {
+								        script : ScriptBuf::from(Address),
+								        amount: amount
+						        }
+			        })
+        });
+        
+        PayoutSettlement {
+            transaction: tx,
+            fee: fee
+        }
+	    }
+	    
+	  pub fn add_sig(&mut self, private_key: &SecretKey) -> Result<(), Error> {
+				// follows same pseudo code as earlier payyout-update struct.
+			}
+
+    pub fn build(self) Transaction {
+						self.transaction
+		}
+} 
+```
+
+### Implementation Code for Payout Settlement Struct
+
+---
+
+```rust
+
+// Create a random previous output transaction (prev_update_tx)
+let prev_update_tx = Transaction {
+    version: 2,
+    lock_time: 0,
+    input: vec![TxIn {
+        previous_output: OutPoint::from("prev_update_out"),
+        sequence: 0xFFFFFFFF,
+        witness: vec![],
+    }],
+    output: vec![TxOut {
+        value: 100 * 100_000_000, // 100 BTC
+        script_pubkey: TAPROOT_KEY,
+    }],
+};
+
+let (_, latest_eltoo_out_address) = generate_random_pubkey();
+
+let payout_map = HashMap<Address , Amount>::new([
+									(ALICE , 20),
+									(BOB , 30),
+									(CHARLIE , 10),
+									(DAVID , 40),
+									]);
+
+let payout_settlement = PayoutSettlement::new(latest_eltoo_out_address, payout_map);
+
+// Generate random private keys
+let secp = Secp256k1::new();
+let privkey1 = SecretKey::new(&mut rng);
+
+// Add signatures with random private keys
+payout_settlement.add_sig(&privkey1).unwrap();
+
+// Build and print the transaction
+let final_tx = payout_settlement.build();
+```
+
+## Dependencies
+
+- Rust-bitcoin crate
+- zmq and other networking crates.
+
+## Testing and Documentation
+
+- Unit tests for individual modules and integration tests for the overall system.
+    - includes spining up local regtest node and executing a chain of transaction flows.
+- Example usages in the `examples/` directory
+
+## Expected File Structure
+
+```rust
+rust-uhpo/
+├── src/
+│   ├── lib.rs
+│   ├── transaction/
+│   │   ├── mod.rs
+│   │   ├── payout_update.rs
+│   │   ├── payout_settlement.rs
+│   ├── network/
+│   └── utils/
+│       ├── mod.rs
+│       └── ... (utility modules)
+├── tests/
+│   └── ... (integration tests)
+├── examples/
+│   └── ... (example usages)
+├── Cargo.toml
+└── README.md
+```

--- a/node/uhpo/src/error.rs
+++ b/node/uhpo/src/error.rs
@@ -1,0 +1,48 @@
+use core::fmt;
+
+use bitcoin::sighash::TaprootError;
+
+#[derive(Debug)]
+pub enum UhpoError {
+    TaprootError(TaprootError),
+    Secp256k1Error(bitcoin::secp256k1::Error),
+    NoPrevUpdateTxOut,
+    Other(String),
+}
+
+impl From<TaprootError> for UhpoError {
+    fn from(err: TaprootError) -> Self {
+        UhpoError::TaprootError(err)
+    }
+}
+
+impl From<bitcoin::secp256k1::Error> for UhpoError {
+    fn from(err: bitcoin::secp256k1::Error) -> Self {
+        UhpoError::Secp256k1Error(err)
+    }
+}
+
+impl fmt::Display for UhpoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UhpoError::TaprootError(err) => write!(f, "Taproot error: {}", err),
+            UhpoError::Secp256k1Error(err) => {
+                write!(f, "Signature verification error: {}", err)
+            }
+            UhpoError::NoPrevUpdateTxOut => {
+                write!(f, "No previous update transaction output provided")
+            }
+            UhpoError::Other(msg) => write!(f, "Other error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for UhpoError {}
+
+impl UhpoError {
+    pub fn new_other_error(message: &str) -> Self {
+        UhpoError::Other(message.to_string())
+    }
+}
+
+

--- a/node/uhpo/src/error.rs
+++ b/node/uhpo/src/error.rs
@@ -44,5 +44,3 @@ impl UhpoError {
         UhpoError::Other(message.to_string())
     }
 }
-
-

--- a/node/uhpo/src/lib.rs
+++ b/node/uhpo/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod payout_settlement;
+pub mod payout_update;

--- a/node/uhpo/src/lib.rs
+++ b/node/uhpo/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod error;
 pub mod payout_settlement;
 pub mod payout_update;

--- a/node/uhpo/src/payout_settlement.rs
+++ b/node/uhpo/src/payout_settlement.rs
@@ -1,9 +1,159 @@
 use std::collections::HashMap;
 
-use bitcoin::{io::Error, secp256k1::SecretKey, Address, Transaction};
+use bitcoin::{
+    absolute::LockTime,
+    hashes::Hash,
+    key::Secp256k1,
+    secp256k1::{Message, Scalar, SecretKey},
+    sighash::{Prevouts, SighashCache, TaprootError},
+    transaction::Version,
+    Address, Amount, OutPoint, TapSighashType, Transaction, TxIn, TxOut, Txid,
+};
 
-pub struct PayoutSettlement {
+pub struct PayoutSettlement<'a> {
     transaction: Transaction,
+    prevouts: &'a TxOut,
 }
 
-impl PayoutSettlement {}
+impl<'a> PayoutSettlement<'a> {
+    pub fn new(latest_eltoo_out: &'a Transaction, payout_map: &HashMap<Address, Amount>) -> Self {
+        let mut settlement_tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: latest_eltoo_out.compute_txid(),
+                    vout: 0,
+                },
+                ..Default::default()
+            }],
+            output: vec![],
+        };
+
+        payout_map.iter().for_each(|(address, amount)| {
+            settlement_tx.output.push(TxOut {
+                script_pubkey: address.script_pubkey(),
+                value: *amount,
+            })
+        });
+
+        PayoutSettlement {
+            transaction: settlement_tx,
+            prevouts: &latest_eltoo_out.output[0],
+        }
+    }
+
+    pub fn add_sig(&mut self, private_key: &SecretKey, tweak: &Scalar) -> Result<(), TaprootError> {
+        let secp = Secp256k1::new();
+        let keypair = private_key.keypair(&secp);
+
+        let mut sighash_cache = SighashCache::new(self.transaction.clone());
+
+        let sighash = sighash_cache.taproot_key_spend_signature_hash(
+            0,
+            &Prevouts::All(&[self.prevouts]),
+            TapSighashType::All,
+        )?;
+
+        let message = Message::from_digest(sighash.as_raw_hash().to_byte_array());
+        let tweaked_keypair = keypair
+            .add_xonly_tweak(&secp, tweak)
+            .map_err(|_| TaprootError::InvalidSighashType(0))?;
+
+        let signature =
+            secp.sign_schnorr_with_rng(&message, &tweaked_keypair, &mut rand::thread_rng());
+        let mut vec_sig = signature.serialize().to_vec();
+        vec_sig.push(0x01);
+
+        secp.verify_schnorr(&signature, &message, &tweaked_keypair.x_only_public_key().0)
+            .unwrap();
+
+        self.transaction.input[0].witness.push(vec_sig);
+
+        Ok(())
+    }
+
+    pub fn build(self) -> Transaction {
+        self.transaction
+    }
+}
+
+// unit tests
+#[cfg(test)]
+mod tests {
+    use bitcoin::{key::Keypair, secp256k1::All, Network, Script, ScriptBuf};
+    use rand::Rng;
+
+    use super::*;
+
+    fn setup(miner_count: u64) -> (Secp256k1<All>, Keypair, HashMap<Address, Amount>, u64) {
+        let secp = Secp256k1::new();
+        let mut rng = rand::thread_rng();
+
+        let data: [u8; 32] = rng.gen();
+        let keypair = SecretKey::from_slice(&data).unwrap().keypair(&secp);
+
+        let mut total_amount = 0;
+        let cashout_map: HashMap<Address, Amount> = (0..miner_count)
+            .map(|_| {
+                let data: [u8; 32] = rng.gen();
+                let keypair = SecretKey::from_slice(&data).unwrap().keypair(&secp);
+                let new_user_address: Address =
+                    Address::p2tr(&secp, keypair.x_only_public_key().0, None, Network::Regtest);
+
+                let amount = rng.gen::<u32>();
+                total_amount += amount as u64;
+                (new_user_address, Amount::from_sat(amount as u64))
+            })
+            .collect();
+
+        (secp, keypair, cashout_map, total_amount)
+    }
+
+    #[test]
+    fn test_payout_settlement() {
+        let (_, _, cashout_map, total_amount) = setup(3);
+        let latest_payout_update = create_dummy_transaction(Amount::from_sat(total_amount + 1000));
+
+        let settlement_tx = PayoutSettlement::new(&latest_payout_update, &cashout_map).build();
+
+        assert!(settlement_tx.output.len() == 3);
+        assert!(settlement_tx.input.len() == 1);
+
+        settlement_tx.output.iter().for_each(|o| {
+            let address = Address::from_script(&o.script_pubkey, Network::Regtest).unwrap();
+
+            assert!(cashout_map.get(&address).unwrap() == &o.value);
+        });
+    }
+
+    #[test]
+    fn test_add_sig() {
+        let (secp, keypair, cashout_map, _) = setup(3);
+        let latest_payout_update = create_dummy_transaction(Amount::from_sat(1000));
+
+        let mut payout_settlement = PayoutSettlement::new(&latest_payout_update, &cashout_map);
+        let tweak = Scalar::from_be_bytes([0; 32]).unwrap();
+
+        payout_settlement
+            .add_sig(&keypair.secret_key(), &tweak)
+            .unwrap();
+
+        assert!(payout_settlement.transaction.input[0].witness.len() == 1);
+    }
+
+    fn create_dummy_transaction(amount_out: Amount) -> Transaction {
+        let tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![],
+            output: vec![TxOut {
+                value: amount_out,
+                script_pubkey: ScriptBuf::default(),
+            }],
+        };
+        tx
+    }
+}
+
+

--- a/node/uhpo/src/payout_settlement.rs
+++ b/node/uhpo/src/payout_settlement.rs
@@ -1,0 +1,9 @@
+use std::collections::HashMap;
+
+use bitcoin::{io::Error, secp256k1::SecretKey, Address, Transaction};
+
+pub struct PayoutSettlement {
+    transaction: Transaction,
+}
+
+impl PayoutSettlement {}

--- a/node/uhpo/src/payout_update.rs
+++ b/node/uhpo/src/payout_update.rs
@@ -211,7 +211,6 @@ mod tests {
 
         let coinbase_tx = create_dummy_transaction();
         let prev_update_tx = create_dummy_transaction();
-
         let projected_fee = Amount::from_sat(1000);
 
         let payout_update = PayoutUpdate::new(

--- a/node/uhpo/src/payout_update.rs
+++ b/node/uhpo/src/payout_update.rs
@@ -1,0 +1,161 @@
+use std::fmt::Error;
+
+use bitcoin::{
+    absolute::LockTime,
+    hashes::Hash,
+    key::Secp256k1,
+    secp256k1::{Message, Scalar, SecretKey},
+    sighash::{Prevouts, SighashCache, TaprootError},
+    transaction::Version,
+    Address, Amount, OutPoint, ScriptBuf, Sequence, TapSighashType, Transaction, TxIn, TxOut,
+    Witness,
+};
+
+struct PayoutUpdate<'a> {
+    transaction: Transaction,
+    coinbase_txout: &'a TxOut,
+    prev_update_txout: Option<&'a TxOut>,
+}
+
+impl<'a> PayoutUpdate<'a> {
+    fn new(
+        prev_update_tx: Option<&'a Transaction>,
+        coinbase_tx: &'a Transaction,
+        next_out_address: Address,
+        projected_fee: u64,
+    ) -> Result<Self, Error> {
+        let prev_update_txout = prev_update_tx.map(|tx| &tx.output[0]);
+        let coinbase_txout = &coinbase_tx.output[0];
+
+        let payout_update_tx = build_transaction(
+            coinbase_tx,
+            prev_update_tx,
+            next_out_address,
+            projected_fee,
+            coinbase_txout,
+            prev_update_txout,
+        )?;
+
+        Ok(PayoutUpdate {
+            transaction: payout_update_tx,
+            coinbase_txout,
+            prev_update_txout,
+        })
+    }
+
+    fn add_coinbase_sig(
+        &mut self,
+        private_key: &SecretKey,
+        tweak: &Scalar,
+    ) -> Result<(), TaprootError> {
+        add_signature(
+            &mut self.transaction,
+            0,
+            &[self.coinbase_txout],
+            private_key,
+            tweak,
+        )
+    }
+
+    fn add_prevout_sig(
+        &mut self,
+        private_key: &SecretKey,
+        tweak: &Scalar,
+    ) -> Result<(), TaprootError> {
+        let prev_update_txout = self
+            .prev_update_txout
+            .ok_or(TaprootError::InvalidSighashType(0))?;
+        add_signature(
+            &mut self.transaction,
+            1,
+            &[prev_update_txout],
+            private_key,
+            tweak,
+        )
+    }
+
+    fn build(self) -> Transaction {
+        self.transaction
+    }
+}
+
+fn build_transaction(
+    coinbase_tx: &Transaction,
+    prev_update_tx: Option<&Transaction>,
+    next_out_address: Address,
+    projected_fee: u64,
+    coinbase_txout: &TxOut,
+    prev_update_txout: Option<&TxOut>,
+) -> Result<Transaction, Error> {
+    let mut total_amount = coinbase_txout.value;
+    if let Some(tx_out) = prev_update_txout {
+        total_amount += tx_out.value;
+    }
+
+    let mut payout_update_tx = Transaction {
+        version: Version::TWO,
+        lock_time: LockTime::ZERO,
+        input: vec![],
+        output: vec![],
+    };
+
+    payout_update_tx.input.push(TxIn {
+        previous_output: OutPoint {
+            txid: coinbase_tx.compute_txid(),
+            vout: 0,
+        },
+        script_sig: ScriptBuf::new(),
+        sequence: Sequence::MAX,
+        witness: Witness::default(),
+    });
+
+    if let Some(tx) = prev_update_tx {
+        payout_update_tx.input.push(TxIn {
+            previous_output: OutPoint {
+                txid: tx.compute_txid(),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::default(),
+        });
+    }
+
+    payout_update_tx.output.push(TxOut {
+        value: total_amount - Amount::from_sat(projected_fee),
+        script_pubkey: next_out_address.script_pubkey(),
+    });
+
+    Ok(payout_update_tx)
+}
+
+fn add_signature(
+    transaction: &mut Transaction,
+    input_idx: usize,
+    prevouts: &[&TxOut],
+    private_key: &SecretKey,
+    tweak: &Scalar,
+) -> Result<(), TaprootError> {
+    let secp = Secp256k1::new();
+    let keypair = private_key.keypair(&secp);
+
+    let mut sighash_cache = SighashCache::new(transaction.clone());
+    let sighash = sighash_cache.taproot_key_spend_signature_hash(
+        input_idx,
+        &Prevouts::All(prevouts),
+        TapSighashType::All,
+    )?;
+
+    let message = Message::from_digest(sighash.as_raw_hash().to_byte_array());
+    let tweaked_keypair = keypair
+        .add_xonly_tweak(&secp, tweak)
+        .map_err(|_| TaprootError::InvalidSighashType(0))?;
+
+    let signature = secp.sign_schnorr_no_aux_rand(&message, &tweaked_keypair);
+    let mut vec_sig = signature.serialize().to_vec();
+    vec_sig.push(0x01);
+
+    transaction.input[input_idx].witness.push(vec_sig);
+
+    Ok(())
+}

--- a/node/uhpo/tests/standard_flow.rs
+++ b/node/uhpo/tests/standard_flow.rs
@@ -1,0 +1,310 @@
+mod utils;
+
+use std::collections::HashMap;
+
+use bitcoin::{
+    absolute::LockTime,
+    hashes::Hash,
+    key::{Keypair, Secp256k1},
+    opcodes::OP_0,
+    script,
+    secp256k1::Scalar,
+    taproot::TaprootBuilder,
+    transaction::Version,
+    Address, Amount, Network, OutPoint, PublicKey, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
+    Txid, Witness,
+};
+use bitcoincore_rpc::RpcApi;
+use rand::Rng;
+
+use utils::*;
+
+/**
+ * Test that the standard flow works
+ * (Reference Image)[https://gist.githubusercontent.com/pool2win/77bb9b98f9f3b8c0f90963343c3c840f/raw/8fa2481728e7c12d553608af23ca6e551c7c90c1/uhpo-success.png]
+ *
+ * Test Case follows above Execution Flow
+ * - uses Nigiri for Regtest.
+ *
+ * Flow
+ * - first block - mined by alice
+ * - second block - mined by bob
+ * - third block - mined by carol
+ *
+ * block 101 - payout-update
+ * block 102 - payout-update
+ * block 103 - payout-update and payout-settlement
+ */
+
+struct UhpoState {
+    payout_update_kp: Keypair,
+    payout_update_tx: Transaction,
+    payout_settlement_tx: Transaction,
+}
+
+#[test]
+fn standard_flow() {
+    // -- Setup -- //
+    let (secp, miners) = setup(3);
+
+    let miner_addresses: Vec<Address> = miners
+        .iter()
+        .map(|m| Address::p2pkh(&PublicKey::new(m.public_key()), Network::Regtest))
+        .collect();
+
+    let client = bitcoincore_rpc::Client::new(
+        "http://localhost:18443",
+        bitcoincore_rpc::Auth::UserPass(String::from("admin1"), String::from("123")),
+    )
+    .unwrap();
+
+    let inital_block_num = client.get_block_count().unwrap();
+    let block_reward =
+        Amount::from_btc(50_f64 / 2_f64.powf((inital_block_num as u32 / 150_u32) as f64)).unwrap();
+
+    // Mine 0..3 blocks
+    let mut uhpo_entries: Vec<UhpoState> = Vec::new();
+
+    (0..3).for_each(|i| {
+        // -- Mine First BLock -- //
+        let (_, coinbase_kp) = generate_taproot_address_nums();
+
+        let (coinbase_addr, coinbase_tr_info) = generate_coinbase_address(
+            coinbase_kp.x_only_public_key().0,
+            &miners[i].x_only_public_key().0,
+        )
+        .unwrap();
+
+        //   -- payout-build/settlement and cache
+        let coinbase_tx = &compute_coinbase_tx(
+            coinbase_addr.script_pubkey(),
+            (client.get_block_count().unwrap() + 1_u64)
+                .try_into()
+                .unwrap(),
+            block_reward,
+        );
+        let (_, payout_update_kp) = generate_taproot_address_nums();
+
+        let (prev_update_tx, prev_update_poolkp, prev_update_tweak) = if i == 0 {
+            (None, None, None)
+        } else {
+            (
+                Some(&uhpo_entries[i - 1].payout_update_tx),
+                Some(uhpo_entries[i - 1].payout_update_kp),
+                {
+                    Some(
+                        TaprootBuilder::new()
+                            .finalize(
+                                &secp,
+                                uhpo_entries[i - 1].payout_update_kp.x_only_public_key().0,
+                            )
+                            .unwrap()
+                            .tap_tweak()
+                            .to_scalar(),
+                    )
+                },
+            )
+        };
+
+        let payout_update_taptweak = Some(
+            TaprootBuilder::new()
+                .finalize(&secp, payout_update_kp.x_only_public_key().0)
+                .unwrap()
+                .tap_tweak()
+                .to_scalar(),
+        );
+
+        let (payout_update_tx, payout_settlement_tx) = uhpo_txs(
+            coinbase_tx,
+            prev_update_tx,
+            coinbase_kp,
+            prev_update_poolkp,
+            payout_update_kp,
+            &miner_addresses,
+            i as u64 + 1,
+            block_reward,
+            coinbase_tr_info.tap_tweak().to_scalar(),
+            prev_update_tweak,
+            payout_update_taptweak,
+        );
+
+        let uhpo_state = UhpoState {
+            payout_update_kp,
+            payout_update_tx,
+            payout_settlement_tx,
+        };
+
+        uhpo_entries.push(uhpo_state);
+
+        generate_block_to_address(&coinbase_addr).unwrap();
+    });
+
+    let current_block_count = client.get_block_count().unwrap();
+
+    assert!(current_block_count - inital_block_num == 3);
+
+    let payout_update_101_txid = client.send_raw_transaction(&uhpo_entries[0].payout_update_tx);
+    assert!(payout_update_101_txid.is_err());
+
+    mine_blocks(97).unwrap();
+
+    // -- payout-update : 101 -- //
+    let payout_update_101_txid = client
+        .send_raw_transaction(&uhpo_entries[0].payout_update_tx)
+        .unwrap();
+    assert!(payout_update_101_txid == uhpo_entries[0].payout_update_tx.compute_txid());
+
+    mine_blocks(1).unwrap();
+
+    // -- payout-update : 102 -- //
+    let payout_update_102_txid = client
+        .send_raw_transaction(&uhpo_entries[1].payout_update_tx)
+        .unwrap();
+    assert!(payout_update_102_txid == uhpo_entries[1].payout_update_tx.compute_txid());
+    mine_blocks(1).unwrap();
+
+    // -- payout-update : 103 -- //
+    let payout_update_103_txid = client
+        .send_raw_transaction(&uhpo_entries[2].payout_update_tx)
+        .unwrap();
+    assert!(payout_update_103_txid == uhpo_entries[2].payout_update_tx.compute_txid());
+    mine_blocks(1).unwrap();
+
+    // -- payout-settlement : 103 -- //
+    let payout_settlement_103_txid = client
+        .send_raw_transaction(&uhpo_entries[2].payout_settlement_tx)
+        .unwrap();
+    assert!(payout_settlement_103_txid == uhpo_entries[2].payout_settlement_tx.compute_txid());
+
+    // check states and balances
+    // states - assertions, balances
+}
+
+fn compute_coinbase_tx(
+    script_pubkey: ScriptBuf,
+    current_block: i64,
+    current_block_reward: Amount,
+) -> Transaction {
+    let witness_commitment =
+        "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9";
+
+    let mut tx = Transaction {
+        version: Version::TWO,
+        lock_time: LockTime::ZERO,
+        input: vec![],
+        output: vec![],
+    };
+
+    let mut vin = TxIn {
+        previous_output: OutPoint {
+            txid: Txid::all_zeros(),
+            vout: 0xffffffff,
+        },
+        script_sig: script::Builder::new()
+            .push_int(current_block)
+            .push_opcode(OP_0)
+            .into_script(),
+        sequence: Sequence::MAX,
+        witness: Witness::new(),
+    };
+
+    vin.witness.push(
+        0x0000000000000000000000000000000000000000000000000000000000000000_usize.to_be_bytes(),
+    );
+
+    let vouts = vec![
+        TxOut {
+            script_pubkey: script_pubkey,
+            value: current_block_reward,
+        },
+        TxOut {
+            script_pubkey: hex::decode(witness_commitment)
+                .expect("Failed to decode hex string")
+                .into(),
+            value: Amount::from_sat(0),
+        },
+    ];
+
+    tx.input.push(vin);
+    tx.output.extend(vouts);
+
+    tx
+}
+
+fn distribute_payouts_with_rand(
+    miners: &Vec<Address>,
+    total_amount: Amount,
+) -> HashMap<Address, Amount> {
+    let mut payout_map = HashMap::new();
+    let mut rng = rand::thread_rng();
+    let mut remaining_amount = total_amount;
+
+    for (index, miner) in miners.iter().enumerate() {
+        let amount = if miners.len() - 1 == index {
+            remaining_amount
+        } else {
+            let random_amount = Amount::from_sat(rng.gen_range(0..remaining_amount.to_sat()));
+            remaining_amount -= random_amount;
+            random_amount
+        };
+        payout_map.insert(miner.clone(), amount);
+    }
+
+    payout_map
+}
+
+fn uhpo_txs(
+    coinbase_tx: &Transaction,
+    prev_update_tx: Option<&Transaction>,
+    coinbase_poolkp: Keypair,
+    prev_update_kp: Option<Keypair>,
+    update_poolkp: Keypair,
+    miner_addresses: &Vec<Address>,
+    block_count: u64,
+    current_block_reward: Amount,
+    coinbase_tweak: Scalar,
+    prev_update_tweak: Option<Scalar>,
+    cur_update_tweak: Option<Scalar>,
+) -> (Transaction, Transaction) {
+    let secp = Secp256k1::new();
+
+    let update_pk = Address::p2tr(
+        &secp,
+        update_poolkp.x_only_public_key().0,
+        None,
+        Network::Regtest,
+    );
+
+    let mut payout_update_builder = uhpo::payout_update::PayoutUpdate::new(
+        prev_update_tx,
+        coinbase_tx,
+        update_pk,
+        Amount::from_sat(500),
+    )
+    .unwrap();
+
+    payout_update_builder
+        .add_coinbase_sig(&coinbase_poolkp.secret_key(), &Some(coinbase_tweak))
+        .unwrap();
+
+    if let Some(prev_update_kp) = prev_update_kp {
+        payout_update_builder
+            .add_prev_update_sig(&prev_update_kp.secret_key(), &prev_update_tweak)
+            .unwrap();
+    }
+
+    let payout_update_tx = payout_update_builder.build();
+
+    let miner_share_record = distribute_payouts_with_rand(
+        miner_addresses,
+        (current_block_reward - Amount::from_sat(600)) * block_count,
+    );
+    let mut payout_settlement_tx =
+        uhpo::payout_settlement::PayoutSettlement::new(&payout_update_tx, &miner_share_record);
+
+    payout_settlement_tx
+        .add_sig(&update_poolkp.secret_key(), &cur_update_tweak)
+        .unwrap();
+
+    (payout_update_tx.clone(), payout_settlement_tx.build())
+}

--- a/node/uhpo/tests/standard_flow.rs
+++ b/node/uhpo/tests/standard_flow.rs
@@ -24,7 +24,7 @@ use utils::*;
  * (Reference Image)[https://gist.githubusercontent.com/pool2win/77bb9b98f9f3b8c0f90963343c3c840f/raw/8fa2481728e7c12d553608af23ca6e551c7c90c1/uhpo-success.png]
  *
  * Test Case follows above Execution Flow
- * - uses Nigiri for Regtest.
+ * - Tested in Regtest Environment.
  *
  * Flow
  * - first block - mined by alice
@@ -47,6 +47,13 @@ struct UhpoState {
 fn standard_flow() {
     // -- Setup -- //
     let (secp, miner_addresses, miners, btcd_client) = setup(3);
+
+    // using short hand clossure to mine blocks
+    let mine_blocks = |nblocks| {
+        for _ in 0..nblocks {
+            btcd_client.generate_to_address(1, &Address::p2shwsh(&script::Builder::new().push_opcode(OP_0).into_script(), Network::Regtest)).unwrap();
+        }
+    };
 
     // compute Current block reward
     // Regtest Has halving for every 150 blocks making current block reward unpredictable. Each testcase mines about 110 blocks
@@ -145,31 +152,31 @@ fn standard_flow() {
     assert!(payout_update_101.is_err());
     assert_eq!(current_block_count - inital_block_num, 3);
 
-    mine_blocks(97).unwrap();
+    mine_blocks(97);
 
     // -- payout-update : 101 -- //
     let payout_update_101_txid: Txid = btcd_client
         .send_raw_transaction(&uhpo_entries[0].payout_update_tx)
         .unwrap();
-    mine_blocks(1).unwrap();
+    mine_blocks(1);
 
     // -- payout-update : 102 -- //
     let payout_update_102_txid = btcd_client
         .send_raw_transaction(&uhpo_entries[1].payout_update_tx)
         .unwrap();
-    mine_blocks(1).unwrap();
+    mine_blocks(1);
 
     // -- payout-update : 103 -- //
     let payout_update_103_txid = btcd_client
         .send_raw_transaction(&uhpo_entries[2].payout_update_tx)
         .unwrap();
-    mine_blocks(1).unwrap();
+    mine_blocks(1);
 
     // -- payout-settlement : 103 -- //
     let payout_settlement_103_txid = btcd_client
         .send_raw_transaction(&uhpo_entries[2].payout_settlement_tx)
         .unwrap();
-    mine_blocks(1).unwrap();
+    mine_blocks(1);
 
     assert_eq!(
         payout_update_101_txid,

--- a/node/uhpo/tests/utils.rs
+++ b/node/uhpo/tests/utils.rs
@@ -1,48 +1,66 @@
-use std::{io::Error, process::Command};
+
+use std::{collections::HashMap, io::Error, process::Command};
 
 use bitcoin::{
     key::{Keypair, Secp256k1},
-    opcodes::all::{OP_CHECKSIG, OP_CSV, OP_DROP},
+    opcodes::{
+        all::{OP_CHECKSIG, OP_CSV, OP_DROP},
+        OP_0,
+    },
     script,
     secp256k1::{All, SecretKey},
-    taproot::{TaprootBuilder, TaprootSpendInfo},
-    Address, Network, ScriptBuf, XOnlyPublicKey,
+    taproot::{TaprootBuilder, TaprootBuilderError, TaprootSpendInfo},
+    Address, Network, PublicKey, ScriptBuf, XOnlyPublicKey,
 };
+use bitcoincore_rpc::Client;
 use rand::Rng;
 
-pub fn setup(n: u64) -> (Secp256k1<All>, Vec<Keypair>) {
+
+// -- common setup -- //
+pub fn setup(n: u64) -> (Secp256k1<All>, Vec<Address>, Vec<Keypair>, Client ) {
     let secp = Secp256k1::new();
     let mut rng = rand::thread_rng();
 
-    // let alice = SecretKey::from_slice(
-    //     &hex::decode("b6a3de6f252db639b5601152af470cd290d317b45c5fa9cf0c84e4ccb4d7166b").unwrap(),
-    // )
+    let mut keypairs = Vec::new();
 
-    let mut keys = Vec::new();
     for _ in 0..n {
         let data: [u8; 32] = rng.gen();
         let keypair = SecretKey::from_slice(&data).unwrap().keypair(&secp);
-        keys.push(keypair);
+        keypairs.push(keypair);
     }
-    (secp, keys)
+
+    let btc_client = Client::new(
+        "http://localhost:18443",
+        bitcoincore_rpc::Auth::UserPass(String::from("admin1"), String::from("123")),
+    )
+    .expect("Error creating rpc client");
+
+    let miner_addresses: Vec<Address> = keypairs
+        .iter()
+        .map(|m| Address::p2pkh(&PublicKey::new(m.public_key()), Network::Regtest))
+        .collect();
+
+    (secp, miner_addresses, keypairs, btc_client )
 }
 
+// uses nigiri rpc to invoke bitcoin-cli to mine desired block
 pub fn mine_blocks(nblocks: u64) -> Result<(), Error> {
     let output = Command::new("nigiri")
         .arg("rpc")
         .arg("--generate")
         .arg(nblocks.to_string())
-        .output()
-        .expect("Failed to execute command");
+        .output()?;
 
     if output.status.success() {
         return Ok(());
     }
 
-    let err = std::str::from_utf8(&output.stderr)
-        .expect("Failed to convert output to string")
-        .trim()
-        .to_string();
+    let err = std::str::from_utf8(&output.stderr).map_err(|_| {
+        Error::new(
+            std::io::ErrorKind::Other,
+            "Failed to convert output to string",
+        )
+    })?;
 
     Err(Error::new(
         std::io::ErrorKind::Other,
@@ -50,52 +68,33 @@ pub fn mine_blocks(nblocks: u64) -> Result<(), Error> {
     ))
 }
 
-pub fn generate_block_to_address(address: &Address) -> Result<(), Error> {
-    let output = Command::new("nigiri")
-        .arg("rpc")
-        .arg("generatetoaddress")
-        .arg("1")
-        .arg(address.to_string())
-        .output()
-        .expect("Failed to execute command");
 
-    if output.status.success() {
-        return Ok(());
-    }
 
-    let err = std::str::from_utf8(&output.stderr)
-        .expect("Failed to convert output to string")
-        .trim()
-        .to_string();
-
-    Err(Error::new(
-        std::io::ErrorKind::Other,
-        format!("Failed to generate block to address with error: {}", err),
-    ))
-}
-
-pub fn generate_taproot_address_nums() -> (Address, Keypair) {
-    let secp = Secp256k1::new();
-
+// Generate random P2TR address
+pub fn generate_taproot_address_nums(secp: &Secp256k1<All>) -> (Address, Keypair) {
     let mut rng = rand::thread_rng();
     let data: [u8; 32] = rng.gen();
-    let keypair = SecretKey::from_slice(&data).unwrap().keypair(&secp);
-
+    let keypair = SecretKey::from_slice(&data).unwrap().keypair(secp);
     let address = Address::p2tr(&secp, keypair.x_only_public_key().0, None, Network::Regtest);
-
     (address, keypair)
 }
 
+/**
+ * Generate random P2TR address
+ * one of taproot leaves is a timelock script with a 150 block timelock.
+ * this makes sure for the miner to spend the coinbase 50 blocks after coinbase Maturity(100 blocks).
+ *
+ * Keypath Spend              -> poolkey
+ * timelock script path spend -> miner who mined the block
+ */
 pub fn generate_coinbase_address(
+    secp: &Secp256k1<All>,
     poolkey: XOnlyPublicKey,
     timelock_pubkey: &XOnlyPublicKey,
-) -> Result<(Address, TaprootSpendInfo), Error> {
-    let secp = Secp256k1::new();
+) -> Result<(Address, TaprootSpendInfo), TaprootBuilderError> {
     let taproot_spend_info = TaprootBuilder::new()
-        .add_leaf(1, build_timelock_script(150, timelock_pubkey))
-        .expect("Failed to build timelock script")
-        .add_leaf(1, build_timelock_script(150, timelock_pubkey))
-        .expect("Failed to build timelock script")
+        .add_leaf(1, build_timelock_script(150, timelock_pubkey))?
+        .add_leaf(1, script::Builder::new().push_opcode(OP_0).into_script())?
         .finalize(&secp, poolkey)
         .expect("Failed to finalize script");
     Ok((
@@ -104,6 +103,19 @@ pub fn generate_coinbase_address(
     ))
 }
 
+/*
+    TimeLock script
+
+    Stack execution
+    opcodes                  | stack after execution
+                             |
+                             | <sig>
+    OP_PUSHNUM_N             | <sig> <n>
+    OP_CSV                   | <sig> 1|0
+    OP_DROP                  | <sig>
+    pub_timelock             | <sig> <pubkey>
+    OP_CHECKSIG              |  true|false
+*/
 pub fn build_timelock_script(nblocks: i64, pubkey: &XOnlyPublicKey) -> ScriptBuf {
     script::Builder::new()
         .push_int(nblocks)
@@ -112,4 +124,65 @@ pub fn build_timelock_script(nblocks: i64, pubkey: &XOnlyPublicKey) -> ScriptBuf
         .push_x_only_key(pubkey)
         .push_opcode(OP_CHECKSIG)
         .into_script()
+}
+
+
+// Get Balance from Esplora Client
+#[derive(Debug, serde::Deserialize)]
+struct ChainStats {
+    funded_txo_sum: u64,
+    spent_txo_sum: u64,
+}
+
+pub fn get_balance(address: &str) -> Result<u64, BalanceError> {
+    let url = format!("http://localhost:3000/address/{}", address);
+    let response = reqwest::blocking::get(&url)?.text()?;
+
+    let json_data: HashMap<String, serde_json::Value> = serde_json::from_str(&response)?;
+    let chain_stats = json_data.get("chain_stats")
+        .ok_or_else(|| "chain_stats field not found".to_owned())?;
+
+    let chain_stats: ChainStats = serde_json::from_value(chain_stats.clone())?;
+
+    let balance = chain_stats.funded_txo_sum - chain_stats.spent_txo_sum;
+    Ok(balance)
+}
+
+use core::fmt;
+
+#[derive(Debug)]
+pub enum BalanceError {
+    RequestError(reqwest::Error),
+    JsonParseError(serde_json::Error),
+    MissingField(String),
+}
+
+impl fmt::Display for BalanceError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            BalanceError::RequestError(err) => write!(f, "Request error: {}", err),
+            BalanceError::JsonParseError(err) => write!(f, "JSON parse error: {}", err),
+            BalanceError::MissingField(field) => write!(f, "Missing field: {}", field),
+        }
+    }
+}
+
+impl std::error::Error for BalanceError {}
+
+impl From<reqwest::Error> for BalanceError {
+    fn from(err: reqwest::Error) -> Self {
+        BalanceError::RequestError(err)
+    }
+}
+
+impl From<serde_json::Error> for BalanceError {
+    fn from(err: serde_json::Error) -> Self {
+        BalanceError::JsonParseError(err)
+    }
+}
+
+impl From<std::string::String> for BalanceError {
+    fn from(err: std::string::String) -> Self {
+        BalanceError::MissingField(err)
+    }
 }

--- a/node/uhpo/tests/utils.rs
+++ b/node/uhpo/tests/utils.rs
@@ -1,0 +1,115 @@
+use std::{io::Error, process::Command};
+
+use bitcoin::{
+    key::{Keypair, Secp256k1},
+    opcodes::all::{OP_CHECKSIG, OP_CSV, OP_DROP},
+    script,
+    secp256k1::{All, SecretKey},
+    taproot::{TaprootBuilder, TaprootSpendInfo},
+    Address, Network, ScriptBuf, XOnlyPublicKey,
+};
+use rand::Rng;
+
+pub fn setup(n: u64) -> (Secp256k1<All>, Vec<Keypair>) {
+    let secp = Secp256k1::new();
+    let mut rng = rand::thread_rng();
+
+    // let alice = SecretKey::from_slice(
+    //     &hex::decode("b6a3de6f252db639b5601152af470cd290d317b45c5fa9cf0c84e4ccb4d7166b").unwrap(),
+    // )
+
+    let mut keys = Vec::new();
+    for _ in 0..n {
+        let data: [u8; 32] = rng.gen();
+        let keypair = SecretKey::from_slice(&data).unwrap().keypair(&secp);
+        keys.push(keypair);
+    }
+    (secp, keys)
+}
+
+pub fn mine_blocks(nblocks: u64) -> Result<(), Error> {
+    let output = Command::new("nigiri")
+        .arg("rpc")
+        .arg("--generate")
+        .arg(nblocks.to_string())
+        .output()
+        .expect("Failed to execute command");
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let err = std::str::from_utf8(&output.stderr)
+        .expect("Failed to convert output to string")
+        .trim()
+        .to_string();
+
+    Err(Error::new(
+        std::io::ErrorKind::Other,
+        format!("Failed to mine {} blocks with error: {}", nblocks, err),
+    ))
+}
+
+pub fn generate_block_to_address(address: &Address) -> Result<(), Error> {
+    let output = Command::new("nigiri")
+        .arg("rpc")
+        .arg("generatetoaddress")
+        .arg("1")
+        .arg(address.to_string())
+        .output()
+        .expect("Failed to execute command");
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let err = std::str::from_utf8(&output.stderr)
+        .expect("Failed to convert output to string")
+        .trim()
+        .to_string();
+
+    Err(Error::new(
+        std::io::ErrorKind::Other,
+        format!("Failed to generate block to address with error: {}", err),
+    ))
+}
+
+pub fn generate_taproot_address_nums() -> (Address, Keypair) {
+    let secp = Secp256k1::new();
+
+    let mut rng = rand::thread_rng();
+    let data: [u8; 32] = rng.gen();
+    let keypair = SecretKey::from_slice(&data).unwrap().keypair(&secp);
+
+    let address = Address::p2tr(&secp, keypair.x_only_public_key().0, None, Network::Regtest);
+
+    (address, keypair)
+}
+
+pub fn generate_coinbase_address(
+    poolkey: XOnlyPublicKey,
+    timelock_pubkey: &XOnlyPublicKey,
+) -> Result<(Address, TaprootSpendInfo), Error> {
+    let secp = Secp256k1::new();
+    let taproot_spend_info = TaprootBuilder::new()
+        .add_leaf(1, build_timelock_script(150, timelock_pubkey))
+        .expect("Failed to build timelock script")
+        .add_leaf(1, build_timelock_script(150, timelock_pubkey))
+        .expect("Failed to build timelock script")
+        .finalize(&secp, poolkey)
+        .expect("Failed to finalize script");
+    Ok((
+        Address::p2tr_tweaked(taproot_spend_info.output_key(), Network::Regtest),
+        taproot_spend_info,
+    ))
+}
+
+pub fn build_timelock_script(nblocks: i64, pubkey: &XOnlyPublicKey) -> ScriptBuf {
+    script::Builder::new()
+        .push_int(nblocks)
+        .push_opcode(OP_CSV)
+        .push_opcode(OP_DROP)
+        .push_x_only_key(pubkey)
+        .push_opcode(OP_CHECKSIG)
+        .into_script()
+}

--- a/node/uhpo/tests/utils.rs
+++ b/node/uhpo/tests/utils.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, io::Error, process::Command};
+use std::collections::HashMap;
 
 use bitcoin::{
     key::{Keypair, Secp256k1},
@@ -41,30 +41,6 @@ pub fn setup(n: u64) -> (Secp256k1<All>, Vec<Address>, Vec<Keypair>, Client) {
     (secp, miner_addresses, keypairs, btc_client)
 }
 
-// uses nigiri rpc to invoke bitcoin-cli to mine desired block
-pub fn mine_blocks(nblocks: u64) -> Result<(), Error> {
-    let output = Command::new("nigiri")
-        .arg("rpc")
-        .arg("--generate")
-        .arg(nblocks.to_string())
-        .output()?;
-
-    if output.status.success() {
-        return Ok(());
-    }
-
-    let err = std::str::from_utf8(&output.stderr).map_err(|_| {
-        Error::new(
-            std::io::ErrorKind::Other,
-            "Failed to convert output to string",
-        )
-    })?;
-
-    Err(Error::new(
-        std::io::ErrorKind::Other,
-        format!("Failed to mine {} blocks with error: {}", nblocks, err),
-    ))
-}
 
 // Generate random P2TR address
 pub fn generate_taproot_address_nums(secp: &Secp256k1<All>) -> (Address, Keypair) {

--- a/node/uhpo/tests/utils.rs
+++ b/node/uhpo/tests/utils.rs
@@ -1,4 +1,3 @@
-
 use std::{collections::HashMap, io::Error, process::Command};
 
 use bitcoin::{
@@ -15,9 +14,8 @@ use bitcoin::{
 use bitcoincore_rpc::Client;
 use rand::Rng;
 
-
 // -- common setup -- //
-pub fn setup(n: u64) -> (Secp256k1<All>, Vec<Address>, Vec<Keypair>, Client ) {
+pub fn setup(n: u64) -> (Secp256k1<All>, Vec<Address>, Vec<Keypair>, Client) {
     let secp = Secp256k1::new();
     let mut rng = rand::thread_rng();
 
@@ -40,7 +38,7 @@ pub fn setup(n: u64) -> (Secp256k1<All>, Vec<Address>, Vec<Keypair>, Client ) {
         .map(|m| Address::p2pkh(&PublicKey::new(m.public_key()), Network::Regtest))
         .collect();
 
-    (secp, miner_addresses, keypairs, btc_client )
+    (secp, miner_addresses, keypairs, btc_client)
 }
 
 // uses nigiri rpc to invoke bitcoin-cli to mine desired block
@@ -67,8 +65,6 @@ pub fn mine_blocks(nblocks: u64) -> Result<(), Error> {
         format!("Failed to mine {} blocks with error: {}", nblocks, err),
     ))
 }
-
-
 
 // Generate random P2TR address
 pub fn generate_taproot_address_nums(secp: &Secp256k1<All>) -> (Address, Keypair) {
@@ -126,7 +122,6 @@ pub fn build_timelock_script(nblocks: i64, pubkey: &XOnlyPublicKey) -> ScriptBuf
         .into_script()
 }
 
-
 // Get Balance from Esplora Client
 #[derive(Debug, serde::Deserialize)]
 struct ChainStats {
@@ -139,7 +134,8 @@ pub fn get_balance(address: &str) -> Result<u64, BalanceError> {
     let response = reqwest::blocking::get(&url)?.text()?;
 
     let json_data: HashMap<String, serde_json::Value> = serde_json::from_str(&response)?;
-    let chain_stats = json_data.get("chain_stats")
+    let chain_stats = json_data
+        .get("chain_stats")
         .ok_or_else(|| "chain_stats field not found".to_owned())?;
 
     let chain_stats: ChainStats = serde_json::from_value(chain_stats.clone())?;


### PR DESCRIPTION
### Changes Made
Added `uhpo` Transaction builder crate

- This crate provides a way to build `payout-update` and `payout-settlement` Transactions.
- Offers way to Schnorr Sign Uhpo Transactions.
- Includes Standard `happy-flow` execution as described [here](https://gist.githubusercontent.com/pool2win/77bb9b98f9f3b8c0f90963343c3c840f/raw/8fa2481728e7c12d553608af23ca6e551c7c90c1/uhpo-success.png).
- Includes Unit Testing for Transaction Builders.

Integration Tests for this crate uses [nigiri](https://github.com/vulpemventures/nigiri/) for its ease of managing services like `regtest`, `electrs` and `esplora`

Refer [Readme.md]() File for further nigiri installation and usage guide.

### Pending Changes
- add malicious or fail-proof testcase. i,e; spend via `payout-update` timelock.
- add examples for assisting developers on usage of crate
