### PR TITLE
Add uhpo crate with PayoutUpdate and add_signature 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,3 @@ proposal/proposal.bbl
 proposal/proposal.blg
 simulations/logs/*
 simulations/*.toolbox
-venv
-target

--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -128,6 +128,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +152,70 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
+]
+
+[[package]]
+name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals",
+ "bitcoin_hashes",
+]
+
+[[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+
+[[package]]
+name = "bitcoin"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea507acc1cd80fc084ace38544bbcf7ced7c2aa65b653b102de0ce718df668f6"
+dependencies = [
+ "base58ck",
+ "bech32",
+ "bitcoin-internals",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes",
+ "hex-conservative",
+ "hex_lit",
+ "secp256k1",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "340e09e8399c7bd8912f495af6aa58bea0c9214773417ffaa8f6460f93aaee56"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb54da0b28892f3c52203a7191534033e051b6f4b52bc15480681b57b7e036f5"
+dependencies = [
+ "bitcoin-internals",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
 ]
 
 [[package]]
@@ -573,6 +643,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex_lit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +889,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "predicates"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +958,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
 ]
 
 [[package]]
@@ -956,6 +1068,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
+dependencies = [
+ "bitcoin_hashes",
+ "rand",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1433bd67156263443f14d603720b082dd3121779323fce20cba2aa07b874bc1b"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1305,6 +1437,16 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "uhpo"
+version = "0.1.0"
+dependencies = [
+ "bitcoin",
+ "mockall",
+ "rand",
+ "secp256k1",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -5,5 +5,6 @@ members = [
     "config",
     "connection",    
     "run",
-    "protocol"
+    "protocol",
+    "uhpo"
 ]

--- a/node/uhpo/Cargo.toml
+++ b/node/uhpo/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "uhpo"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bitcoin = {version = "0.32.2" , features = ["rand"] }
+rand = "0.8.5"
+mockall = "0.12.1"
+secp256k1 = "0.29.0"
+
+
+[dev-dependencies]

--- a/node/uhpo/src/crypto/mod.rs
+++ b/node/uhpo/src/crypto/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod signature;
+
+pub use signature::add_signature;

--- a/node/uhpo/src/crypto/signature.rs
+++ b/node/uhpo/src/crypto/signature.rs
@@ -1,0 +1,298 @@
+use bitcoin::{
+    hashes::Hash,
+    secp256k1::{All, Keypair, Message, Scalar, Secp256k1, SecretKey},
+    sighash::{Prevouts, SighashCache},
+    TapSighashType, Transaction, TxOut, XOnlyPublicKey,
+};
+use mockall::automock;
+use rand::{CryptoRng, Rng};
+use secp256k1::schnorr::Signature;
+// use secp256k1::schnorr::Signature;
+
+use crate::UhpoError;
+
+// traits for mock testing
+
+/// Trait for secret key behavior, allowing creation of keypairs.
+#[automock]
+pub trait SecretKeyBehavior<K: KeypairBehavior<E>, E: Secp256k1Behavior + 'static> {
+    fn keypair(&self, secp: &E) -> K;
+}
+
+/// Trait for keypair behavior, allowing tweaking of keypairs, Exclusively used by mock tests to mock Keypair methods
+#[automock]
+pub trait KeypairBehavior<E: Secp256k1Behavior + 'static> {
+    fn add_xonly_tweak(
+        self,
+        secp: &E,
+        tweak: &Scalar,
+    ) -> Result<Keypair, bitcoin::secp256k1::Error>;
+
+    /// Converts the keypair to a standard Keypair type.
+    fn to_keypair(&self) -> Keypair;
+}
+
+/// Trait for secp256k1 behavior, including signing and verification operations.
+#[automock]
+pub trait Secp256k1Behavior {
+    /// Signs a message using Schnorr signature scheme.
+    fn sign_schnorr_with_rng<R: Rng + CryptoRng + 'static>(
+        &self,
+        msg: &Message,
+        keypair: &Keypair,
+        rng: &mut R,
+    ) -> Signature;
+
+    /// Verifies a Schnorr signature.
+    fn verify_schnorr(
+        &self,
+        signature: &Signature,
+        message: &Message,
+        pubkey: &XOnlyPublicKey,
+    ) -> Result<(), bitcoin::secp256k1::Error>;
+}
+
+// Implementations for concrete types
+
+impl SecretKeyBehavior<Keypair, Secp256k1<All>> for SecretKey {
+    fn keypair(&self, secp: &Secp256k1<All>) -> Keypair {
+        self.keypair(secp)
+    }
+}
+
+impl KeypairBehavior<Secp256k1<All>> for Keypair {
+    fn add_xonly_tweak(
+        self,
+        secp: &Secp256k1<All>,
+        tweak: &Scalar,
+    ) -> Result<Keypair, bitcoin::secp256k1::Error> {
+        self.add_xonly_tweak(secp, tweak)
+    }
+
+    fn to_keypair(&self) -> Keypair {
+        self.clone()
+    }
+}
+
+impl Secp256k1Behavior for Secp256k1<All> {
+    fn sign_schnorr_with_rng<R: Rng + CryptoRng>(
+        &self,
+        msg: &Message,
+        keypair: &Keypair,
+        rng: &mut R,
+    ) -> Signature {
+        self.sign_schnorr_with_rng(msg, keypair, rng)
+    }
+
+    fn verify_schnorr(
+        &self,
+        signature: &Signature,
+        message: &Message,
+        pubkey: &XOnlyPublicKey,
+    ) -> Result<(), bitcoin::secp256k1::Error> {
+        self.verify_schnorr(signature, message, pubkey)
+    }
+}
+
+/// Adds a signature to a transaction input.
+///
+/// This function creates a signature for the specified input of a transaction,
+/// optionally applying a tweak to the private key before signing.
+pub fn add_signature<S, K, E>(
+    transaction: &mut Transaction,
+    input_idx: usize,
+    prevouts: &[&TxOut],
+    private_key: S,
+    tweak: Option<&Scalar>,
+    secp: &E,
+) -> Result<(), UhpoError>
+where
+    S: SecretKeyBehavior<K, E>,
+    K: KeypairBehavior<E>,
+    E: Secp256k1Behavior + 'static,
+{
+    // apply tweak if provided
+    let keypair: Keypair = match tweak {
+        Some(tweak) => private_key
+            .keypair(secp)
+            .add_xonly_tweak(secp, tweak)
+            .map_err(UhpoError::KeypairCreationError)?,
+        None => private_key.keypair(secp).to_keypair(),
+    };
+
+    // Compute the sighash
+    let mut sighash_cache = SighashCache::new(transaction.clone());
+    let sighash = sighash_cache.taproot_key_spend_signature_hash(
+        input_idx,
+        &Prevouts::All(prevouts),
+        TapSighashType::All,
+    )?;
+
+    // Create and sign the message
+    let message = Message::from_digest(sighash.as_raw_hash().to_byte_array());
+    let signature = secp.sign_schnorr_with_rng(&message, &keypair, &mut rand::thread_rng());
+
+    // Verify the signature
+    secp.verify_schnorr(&signature, &message, &keypair.x_only_public_key().0)
+        .map_err(UhpoError::SignatureVerificationError)?;
+
+    // Add the signature to the transaction input
+    let mut vec_sig = signature.serialize().to_vec();
+    vec_sig.push(0x01);
+    transaction.input[input_idx].witness.push(vec_sig);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod mock_tests {
+    use crate::crypto::signature::*;
+
+    use bitcoin::{absolute::LockTime, transaction::Version, Amount, ScriptBuf, TxIn};
+    use rand::rngs::ThreadRng;
+    use secp256k1::{Secp256k1, SecretKey};
+
+    // dummy transaction for testing with no inputs
+    pub fn create_dummy_transaction() -> Transaction {
+        Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![],
+            output: vec![TxOut {
+                value: Amount::from_sat(50000000),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        }
+    }
+
+    #[test]
+    fn test_add_signature_with_invalid_tweak_error_key_creation_should_fail() {
+        // setup mocks
+        let mock_secp = MockSecp256k1Behavior::new();
+        let mut mock_keypair = MockKeypairBehavior::new();
+        let mut mock_secret_key = MockSecretKeyBehavior::<
+            MockKeypairBehavior<MockSecp256k1Behavior>,
+            MockSecp256k1Behavior,
+        >::new();
+
+        // add_xonly_tweak on keypair, returns an error
+        mock_keypair
+            .expect_add_xonly_tweak()
+            .return_once(|_: &MockSecp256k1Behavior, _| Err(secp256k1::Error::InvalidTweak));
+
+        // secretKey.keypair returns an MockKeypair
+        mock_secret_key
+            .expect_keypair()
+            .return_once(move |_| mock_keypair);
+
+        let mut transaction = create_dummy_transaction();
+        transaction.input.push(TxIn {
+            ..Default::default()
+        });
+        let prevout = TxOut {
+            value: Amount::from_sat(0),
+            script_pubkey: ScriptBuf::new(),
+        };
+        let tweak = Some(Scalar::random_custom(&mut rand::thread_rng()));
+
+        let result = add_signature(
+            &mut transaction,
+            0,
+            &[&prevout],
+            mock_secret_key,
+            tweak.as_ref(),
+            &mock_secp,
+        );
+
+        assert!(matches!(result, Err(UhpoError::KeypairCreationError(_))));
+    }
+
+    #[test]
+    fn test_add_signature_with_a_bad_signature_should_fail_during_verification() {
+        // setup
+        // valid secp is used in order to generate valid keypair in add_signatures
+        let real_secp = Secp256k1::new();
+
+        // setup mocks
+        let mut mock_secp = MockSecp256k1Behavior::new();
+        let mut mock_keypair = MockKeypairBehavior::<MockSecp256k1Behavior>::new();
+        let mut mock_secret_key = MockSecretKeyBehavior::<
+            MockKeypairBehavior<MockSecp256k1Behavior>,
+            MockSecp256k1Behavior,
+        >::new();
+
+        // add_xonly_tweak on keypair returns a valid keypair
+        mock_keypair
+            .expect_add_xonly_tweak()
+            .return_once(move |_: &MockSecp256k1Behavior, _| {
+                Ok(Keypair::new(&real_secp, &mut rand::thread_rng()))
+            });
+
+        // secretKey.keypair returns an MockKeypair
+        mock_secret_key
+            .expect_keypair()
+            .return_once(move |_| mock_keypair);
+
+        // sign_schnorr_with_rng returns a  signature
+        mock_secp.expect_sign_schnorr_with_rng().return_once(
+            |_: &Message, _: &Keypair, _: &mut ThreadRng| {
+                Signature::from_slice(&[0u8; 64]).unwrap()
+            },
+        );
+
+        // verify_schnorr returns an error
+        mock_secp
+            .expect_verify_schnorr()
+            .return_once(|_, _, _| Err(secp256k1::Error::InvalidSignature));
+
+        let mut transaction = create_dummy_transaction();
+        transaction.input.push(TxIn {
+            ..Default::default()
+        });
+        let prevout = TxOut {
+            value: Amount::from_sat(0),
+            script_pubkey: ScriptBuf::new(),
+        };
+        let tweak = Some(Scalar::random_custom(&mut rand::thread_rng()));
+
+        let result = add_signature(
+            &mut transaction,
+            0,
+            &[&prevout],
+            mock_secret_key,
+            tweak.as_ref(),
+            &mock_secp,
+        );
+
+        assert!(matches!(
+            result,
+            Err(UhpoError::SignatureVerificationError(_))
+        ));
+    }
+
+    #[test]
+    fn test_add_signature_with_a_valid_signature_should_pass() {
+        // setup
+        let secp = Secp256k1::new();
+        let mut transaction = create_dummy_transaction();
+        transaction.input.push(TxIn {
+            ..Default::default()
+        });
+        let prevout = TxOut {
+            value: Amount::from_sat(0),
+            script_pubkey: ScriptBuf::new(),
+        };
+        let tweak = Some(Scalar::random_custom(&mut rand::thread_rng()));
+
+        let result = add_signature(
+            &mut transaction,
+            0,
+            &[&prevout],
+            SecretKey::from_slice(&rand::thread_rng().gen::<[u8; 32]>()).unwrap(),
+            tweak.as_ref(),
+            &secp,
+        );
+
+        assert!(result.is_ok());
+    }
+}

--- a/node/uhpo/src/error.rs
+++ b/node/uhpo/src/error.rs
@@ -1,0 +1,48 @@
+use core::fmt;
+
+use bitcoin::sighash::TaprootError;
+
+#[derive(Debug)]
+pub enum UhpoError {
+    KeypairCreationError(bitcoin::secp256k1::Error),
+    SignatureVerificationError(bitcoin::secp256k1::Error),
+    TaprootError(TaprootError),
+    NoPrevUpdateTxOut,
+    Other(String),
+}
+
+impl From<TaprootError> for UhpoError {
+    fn from(err: TaprootError) -> Self {
+        UhpoError::TaprootError(err)
+    }
+}
+
+impl From<bitcoin::secp256k1::Error> for UhpoError {
+    fn from(err: bitcoin::secp256k1::Error) -> Self {
+        UhpoError::KeypairCreationError(err)
+    }
+}
+
+impl fmt::Display for UhpoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UhpoError::KeypairCreationError(err) => write!(f, "Keypair creation error: {}", err),
+            UhpoError::TaprootError(err) => write!(f, "Taproot error: {}", err),
+            UhpoError::SignatureVerificationError(err) => {
+                write!(f, "Signature verification error: {}", err)
+            }
+            UhpoError::NoPrevUpdateTxOut => {
+                write!(f, "No previous update transaction output provided")
+            }
+            UhpoError::Other(msg) => write!(f, "Other error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for UhpoError {}
+
+impl UhpoError {
+    pub fn new(message: &str) -> Self {
+        UhpoError::Other(message.to_string())
+    }
+}

--- a/node/uhpo/src/lib.rs
+++ b/node/uhpo/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod crypto;
+pub mod error;
+pub mod payout_settlement;
+pub mod payout_update;
+pub mod transaction;
+
+pub use error::UhpoError;
+pub use payout_settlement::PayoutSettlement;
+pub use payout_update::PayoutUpdate;

--- a/node/uhpo/src/payout_settlement.rs
+++ b/node/uhpo/src/payout_settlement.rs
@@ -1,0 +1,3 @@
+pub struct PayoutSettlement {}
+
+impl PayoutSettlement {}

--- a/node/uhpo/src/payout_update.rs
+++ b/node/uhpo/src/payout_update.rs
@@ -1,0 +1,350 @@
+use std::fmt::Error;
+
+use bitcoin::{secp256k1::Scalar, Address, Amount, Transaction, TxOut};
+
+use crate::crypto::signature::{
+    add_signature, KeypairBehavior, Secp256k1Behavior, SecretKeyBehavior,
+};
+use crate::{transaction::TransactionBuilder, UhpoError};
+
+/// `PayoutUpdate` represents an update to a Eltoo style payout.
+pub struct PayoutUpdate {
+    transaction: Transaction,
+
+    // coinbase and prev_update txout's are to be store and used while signing respective inputs
+    coinbase_txout: TxOut,
+    prev_update_txout: Option<TxOut>,
+}
+
+impl PayoutUpdate {
+    /// Creates a new PayoutUpdate instance.
+    ///
+    /// # Arguments
+    /// * `prev_update_tx` - Optional previous update transaction
+    /// * `coinbase_tx` - The coinbase transaction
+    /// * `next_out_address` - The address for the next output
+    /// * `projected_fee` - The projected transaction fee
+    ///
+    /// # Returns
+    /// Result containing a new PayoutUpdate instance or an Error
+    pub fn new(
+        prev_update_tx: Option<Transaction>,
+        coinbase_tx: Transaction,
+        next_out_address: Address,
+        projected_fee: Amount,
+    ) -> Result<Self, Error> {
+        let coinbase_txout = coinbase_tx.output[0].clone();
+
+        // coinbase created by implementation crate would always  have spending vout set to 0
+        let mut builder = TransactionBuilder::new().add_input(coinbase_tx.compute_txid(), 0);
+
+        // Add previous update transaction input if it exists
+        // previous update tx would be None if and only if this is the first update
+        let prev_update_txout = if let Some(tx) = prev_update_tx {
+            builder = builder.add_input(tx.compute_txid(), 0);
+            Some(tx.output[0].clone())
+        } else {
+            None
+        };
+
+        // Calculate total amount from coinbase and previous update
+        let total_amount = prev_update_txout.as_ref().map_or_else(
+            || coinbase_txout.value,
+            |txout| coinbase_txout.value + txout.value,
+        );
+
+        let transaction = builder
+            .add_output(next_out_address, total_amount - projected_fee)
+            .build();
+
+        Ok(PayoutUpdate {
+            transaction,
+            coinbase_txout,
+            prev_update_txout,
+        })
+    }
+
+    /// Adds a signature for the coinbase input.
+    ///
+    /// # Arguments
+    /// * `private_key` - The private key for signing
+    /// * `tweak` - Optional tweak for the private key
+    /// * `secp` - The Secp256k1 context
+    ///
+    /// # Returns
+    /// Result indicating success or an UhpoError
+    pub fn add_coinbase_sig<S, K, E>(
+        &mut self,
+        private_key: S,
+        tweak: Option<&Scalar>,
+        secp: &E,
+    ) -> Result<(), UhpoError>
+    where
+        S: SecretKeyBehavior<K, E>,
+        K: KeypairBehavior<E>,
+        E: Secp256k1Behavior + 'static,
+    {
+        let prevouts = match &self.prev_update_txout {
+            Some(prev_update_txout) => vec![&self.coinbase_txout, prev_update_txout],
+            None => vec![&self.coinbase_txout],
+        };
+
+        add_signature(
+            &mut self.transaction,
+            0, // coinbase input idx
+            &prevouts,
+            private_key,
+            tweak,
+            secp,
+        )
+    }
+
+    /// Adds a signature for the previous update input.
+    ///
+    /// # Arguments
+    /// * `private_key` - The private key for signing
+    /// * `tweak` - Optional tweak for the private key
+    /// * `secp` - The Secp256k1 context
+    ///
+    /// # Returns
+    /// Result indicating success or an UhpoError
+    pub fn add_prev_update_sig<S, K, E>(
+        &mut self,
+        private_key: S,
+        tweak: Option<&Scalar>,
+        secp: &E,
+    ) -> Result<(), UhpoError>
+    where
+        S: SecretKeyBehavior<K, E>,
+        K: KeypairBehavior<E>,
+        E: Secp256k1Behavior + 'static,
+    {
+        let prev_update_txout = self
+            .prev_update_txout
+            .as_ref()
+            .ok_or(UhpoError::NoPrevUpdateTxOut)?;
+        let prevouts = vec![&self.coinbase_txout, prev_update_txout];
+
+        add_signature(
+            &mut self.transaction,
+            1,
+            &prevouts,
+            private_key,
+            tweak,
+            secp,
+        )
+    }
+
+    pub fn build(self) -> Transaction {
+        self.transaction
+    }
+}
+
+// unit tests
+#[cfg(test)]
+mod tests {
+    use crate::crypto::signature::{
+        MockKeypairBehavior, MockSecp256k1Behavior, MockSecretKeyBehavior,
+    };
+
+    use super::*;
+    use bitcoin::{
+        absolute::LockTime, key::Keypair, secp256k1::All, transaction::Version, Network, ScriptBuf,
+    };
+    use rand::Rng;
+    use secp256k1::{Secp256k1, SecretKey};
+
+    // Helper function for setting up tests
+
+    pub fn setup() -> (Secp256k1<All>, Keypair, Address) {
+        let secp = Secp256k1::new();
+        let mut rng = rand::thread_rng();
+
+        let data: [u8; 32] = rng.gen();
+        let keypair = SecretKey::from_slice(&data).unwrap().keypair(&secp);
+
+        let new_payout_address: Address =
+            Address::p2tr(&secp, keypair.x_only_public_key().0, None, Network::Regtest);
+
+        (secp, keypair, new_payout_address)
+    }
+
+    pub fn create_dummy_transaction() -> Transaction {
+        Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![],
+            output: vec![TxOut {
+                value: Amount::from_sat(50000000),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        }
+    }
+
+    #[test]
+    fn test_new_payout_update_only_cb() {
+        let (_, _, new_payout_address) = setup();
+
+        let coinbase_tx = create_dummy_transaction();
+        let prev_update_tx = None;
+        let projected_fee = Amount::from_sat(1000);
+
+        let payout_update = PayoutUpdate::new(
+            prev_update_tx,
+            coinbase_tx,
+            new_payout_address,
+            projected_fee,
+        )
+        .expect("Failed to create payout update");
+
+        assert_eq!(payout_update.transaction.input.len(), 1);
+        assert_eq!(payout_update.transaction.output.len(), 1);
+        assert_eq!(
+            payout_update.transaction.output[0].value,
+            Amount::from_sat(50000000) - projected_fee
+        );
+        assert!(payout_update.prev_update_txout.is_none());
+    }
+
+    #[test]
+    fn test_new_payout_update() {
+        let (_, _, new_payout_address) = setup();
+
+        let coinbase_tx = create_dummy_transaction();
+        let prev_update_tx = create_dummy_transaction();
+        let projected_fee = Amount::from_sat(1000);
+
+        let payout_update = PayoutUpdate::new(
+            Some(prev_update_tx),
+            coinbase_tx,
+            new_payout_address,
+            projected_fee,
+        )
+        .expect("Failed to create payout update");
+
+        assert_eq!(payout_update.transaction.input.len(), 2);
+        assert_eq!(payout_update.transaction.output.len(), 1);
+        assert_eq!(
+            payout_update.transaction.output[0].value,
+            Amount::from_sat(50000000 * 2) - projected_fee
+        );
+        assert!(payout_update.prev_update_txout.is_some());
+    }
+
+    #[test]
+    fn test_add_signature_with_no_tweak() {
+        let (secp, keypair, new_payout_address) = setup();
+
+        let coinbase_tx = create_dummy_transaction();
+        let prev_update_tx = create_dummy_transaction();
+        let projected_fee = Amount::from_sat(1000);
+        let mut payout_update = PayoutUpdate::new(
+            Some(prev_update_tx),
+            coinbase_tx,
+            new_payout_address,
+            projected_fee,
+        )
+        .expect("Failed to create payout update");
+
+        payout_update
+            .add_coinbase_sig(keypair.secret_key(), None, &secp)
+            .expect("Failed to add coinbase signature");
+
+        payout_update
+            .add_prev_update_sig(keypair.secret_key(), None, &secp)
+            .expect("Failed to add prev update signature");
+
+        assert_eq!(payout_update.transaction.input[0].witness.len(), 1);
+        assert_eq!(payout_update.transaction.input[1].witness.len(), 1);
+    }
+
+    #[test]
+    fn test_add_signature_with_tweak() {
+        let (secp, keypair, new_payout_address) = setup();
+
+        let coinbase_tx = create_dummy_transaction();
+        let prev_update_tx = create_dummy_transaction();
+        let projected_fee = Amount::from_sat(1000);
+        let mut payout_update = PayoutUpdate::new(
+            Some(prev_update_tx),
+            coinbase_tx,
+            new_payout_address,
+            projected_fee,
+        )
+        .expect("Failed to create payout update");
+
+        payout_update
+            .add_coinbase_sig(
+                keypair.secret_key(),
+                Some(&Scalar::random_custom(&mut rand::thread_rng())),
+                &secp,
+            )
+            .expect("Failed to add coinbase signature");
+
+        payout_update
+            .add_prev_update_sig(
+                keypair.secret_key(),
+                Some(&Scalar::random_custom(&mut rand::thread_rng())),
+                &secp,
+            )
+            .expect("Failed to add prev update signature");
+
+        assert_eq!(payout_update.transaction.input[0].witness.len(), 1);
+        assert_eq!(payout_update.transaction.input[1].witness.len(), 1);
+    }
+
+    #[test]
+    fn test_add_signature_mock_error_should_fail() {
+        let (_, _, new_payout_address) = setup();
+
+        let coinbase_tx = create_dummy_transaction();
+        let prev_update_tx = create_dummy_transaction();
+        let projected_fee = Amount::from_sat(1000);
+        let mut payout_update = PayoutUpdate::new(
+            Some(prev_update_tx),
+            coinbase_tx,
+            new_payout_address,
+            projected_fee,
+        )
+        .expect("Failed to create payout update");
+
+        // setup mocks
+        let mock_secp = MockSecp256k1Behavior::new();
+
+        let create_mock_secret_key = || {
+            let mut mock_keypair = MockKeypairBehavior::new();
+            let mut mock_secret_key = MockSecretKeyBehavior::<
+                MockKeypairBehavior<MockSecp256k1Behavior>,
+                MockSecp256k1Behavior,
+            >::new();
+
+            // add_xonly_tweak on keypair, returns an error
+            mock_keypair
+                .expect_add_xonly_tweak()
+                .return_once(|_: &MockSecp256k1Behavior, _| Err(secp256k1::Error::InvalidTweak));
+
+            // secretKey.keypair returns an MockKeypair
+            mock_secret_key
+                .expect_keypair()
+                .return_once(move |_| mock_keypair);
+
+            mock_secret_key
+        };
+
+        let result = payout_update.add_coinbase_sig(
+            create_mock_secret_key(),
+            Some(&Scalar::random_custom(&mut rand::thread_rng())),
+            &mock_secp,
+        );
+
+        assert!(matches!(result, Err(UhpoError::KeypairCreationError(_))));
+
+        let result = payout_update.add_prev_update_sig(
+            create_mock_secret_key(),
+            Some(&Scalar::random_custom(&mut rand::thread_rng())),
+            &mock_secp,
+        );
+
+        assert!(matches!(result, Err(UhpoError::KeypairCreationError(_))));
+    }
+}

--- a/node/uhpo/src/transaction/builder.rs
+++ b/node/uhpo/src/transaction/builder.rs
@@ -1,0 +1,68 @@
+use bitcoin::{
+    absolute::LockTime, transaction::Version, Address, Amount, OutPoint, ScriptBuf, Sequence,
+    Transaction, TxIn, TxOut, Txid, Witness,
+};
+/// A builder for constructing Bitcoin transactions.
+pub struct TransactionBuilder {
+    /// The transaction being built.
+    transaction: Transaction,
+}
+
+impl TransactionBuilder {
+    /// Creates a new TransactionBuilder with default values.
+    ///
+    /// # Returns
+    /// A new TransactionBuilder instance with an empty transaction.
+    pub fn new() -> Self {
+        Self {
+            transaction: Transaction {
+                version: Version::TWO,
+                lock_time: LockTime::ZERO,
+                input: vec![],
+                output: vec![],
+            },
+        }
+    }
+
+    /// Adds an input to the transaction.
+    ///
+    /// # Arguments
+    /// * `txid` - The transaction ID of the input
+    /// * `vout` - The output index of the input
+    ///
+    /// # Returns
+    /// Self, allowing for method chaining
+    pub fn add_input(mut self, txid: Txid, vout: u32) -> Self {
+        self.transaction.input.push(TxIn {
+            previous_output: OutPoint { txid, vout },
+            script_sig: ScriptBuf::new(), // Empty script signature (would remain empty since most of txs are p2tr)
+            sequence: Sequence::MAX,      // Set sequence to maximum value
+            witness: Witness::default(),  // Default (empty) witness
+        });
+        self
+    }
+
+    /// Adds an output to the transaction.
+    ///
+    /// # Arguments
+    /// * `address` - The recipient's Bitcoin address
+    /// * `amount` - The amount of Bitcoin to send
+    ///
+    /// # Returns
+    /// Self, allowing for method chaining
+    pub fn add_output(mut self, address: Address, amount: Amount) -> Self {
+        self.transaction.output.push(TxOut {
+            value: amount,
+            script_pubkey: address.script_pubkey(),
+        });
+        self
+    }
+
+    /// Finalizes the transaction building process.
+    ///
+    /// # Returns
+    /// The built Transaction
+    pub fn build(self) -> Transaction {
+        self.transaction
+    }
+}

--- a/node/uhpo/src/transaction/mod.rs
+++ b/node/uhpo/src/transaction/mod.rs
@@ -1,0 +1,3 @@
+mod builder;
+
+pub use builder::TransactionBuilder;


### PR DESCRIPTION
- Add a new module crypto/signature that provides `add_signature
- Add payout_update module to build `PayoutUpdate`
- Using generics and mockall for tests